### PR TITLE
github tools: add fossa license scanning

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -1,0 +1,31 @@
+name: Dependency License Scanning
+
+on:
+  push:
+    branches:
+      - master
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  fossa:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Fossa init
+      run: |- 
+        curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
+        fossa init
+    - name: Set env
+      run: echo ::set-env name=line_number::$(grep -n "project" .fossa.yml | cut -f1 -d:)
+    - name: Configuration
+      run: |-
+        sed -i "${line_number}s|.*|  project: git@github.com:${GITHUB_REPOSITORY}.git|" .fossa.yml
+        cat .fossa.yml
+    - name: Upload dependencies
+      run: fossa analyze --debug
+      env:
+        FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
NOTICE: If this pull request does not apply to your repository, feel free to close this pull request. This is a generated pull request by [github-tools](https://github.com/netlify/github-tools/) to add Fossa license scanning to this repository. The Fossa status check will fail until some code has been added to your master branch.

You can check the status of your scan at https://app.fossa.com/projects/custom%2B17679%2Fgit%40github.com%3Anetlify%2FYOUR_PROJECT.git. If you have any questions or issues related to this (or if you are unable to access the fossa report), please contact us on slack at #crew-internal-tools. This github action only runs upon merge to master so a scan won't exist until this PR is merged in.

To add the license status as a badge on your README copy the following and replace **YOUR_PROJECT** with the name of your repo:
~~~~
[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B17679%2Fgit%40github.com%3Anetlify%2FYOUR_PROJECT.git.svg?type=shield)](https://app.fossa.com/projects/custom%2B17679%2Fgit%40github.com%3Anetlify%2FYOUR_PROJECT.git?ref=badge_shield)
~~~~